### PR TITLE
サンプルコードで page_index が 1 になっている

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ class Sample {
         //＊Jacksonの機能を利用し、EntityからJSONへの変換を行うことも可能
         Map<String, Object> data = new HashMap<>();
         data.put("items_per_page", 10);
-        data.put("page_index", 1);
+        data.put("page_index", 0);
 
         //Mapでレスポンスを受け取る汎用クラスを使い、レスポンスを受け取る
         //＊Jacksonの機能を利用し、EntityからJSONへの変換を行うことも可能


### PR DESCRIPTION
`README.md` 記載のコードを手元で試したところ結果が空っぽになり、原因を調べたところ  `page_index` が 1 始まりではなく 0 始まりであることに気づきました (仕様は確認できず)。
本 `README.md` の他の箇所は 0 が指定されていますが、冒頭のコード例だけ 1 になっていたため、修正を希望します。